### PR TITLE
Move environment variables from terraform_wrapper

### DIFF
--- a/devops/scripts/load_and_validate_env.sh
+++ b/devops/scripts/load_and_validate_env.sh
@@ -83,6 +83,11 @@ else
 
     TRE_URL=$(construct_tre_url "${TRE_ID}" "${LOCATION}" "${AZURE_ENVIRONMENT}")
     export TRE_URL
+
+    # Configure AzureRM provider and backend to use Azure AD to connect to storage accounts
+    export ARM_STORAGE_USE_AZUREAD=true
+    export ARM_USE_AZUREAD=true
+    export ARM_USE_OIDC=true
 fi
 
 # if local debugging is configured, then set vars required by ~/.porter/config.yaml

--- a/devops/scripts/terraform_wrapper.sh
+++ b/devops/scripts/terraform_wrapper.sh
@@ -91,13 +91,6 @@ if [[ -z ${tf_logfile+x} ]]; then
     echo -e "No logfile provided, using ${tf_logfile}\n"
 fi
 
-# Configure AzureRM provider to user Azure AD to connect to storage accounts
-export ARM_STORAGE_USE_AZUREAD=true
-
-# Configure AzureRM backend to user Azure AD to connect to storage accounts
-export ARM_USE_AZUREAD=true
-export ARM_USE_OIDC=true
-
 terraform init -input=false -backend=true -reconfigure \
     -backend-config="resource_group_name=${mgmt_resource_group_name}" \
     -backend-config="storage_account_name=${mgmt_storage_account_name}" \


### PR DESCRIPTION
Moved environment variables from `terraform_wrapper` to make them available in all Make command contexts, fixing the broken show-core-output command.